### PR TITLE
Add level description as a tooltip and move to the left.

### DIFF
--- a/app/src/lib/Level.svelte
+++ b/app/src/lib/Level.svelte
@@ -1,9 +1,17 @@
 <script>
 	/** @type {Concept['level']} */
 	export let level
+
+	const level_descriptions = [
+		'Semantic Primitive',
+		'Semantic Molecule',
+		'Complex with an Insertion Rule',
+		'Complex without an Insertion Rule',
+		'Inexplicable'
+	]
 </script>
 
-<span class={`badge L${level} badge-lg`}>
+<span class={`badge L${level} badge-lg tooltip tooltip-left font-mono`} data-tip={level_descriptions[parseInt(level)]}>
 	L{level}
 </span>
 

--- a/app/src/lib/Occurrences.svelte
+++ b/app/src/lib/Occurrences.svelte
@@ -3,6 +3,6 @@
 	export let occurrences
 </script>
 
-<span class="badge badge-success badge-md tooltip tooltip-right font-mono" data-tip="Occurrences">
+<span class="badge badge-success badge-md tooltip tooltip-left font-mono" data-tip="Occurrences">
 	{occurrences}
 </span>


### PR DESCRIPTION
In addition to the level color, I think it's useful to display the description of the level for new users or those who aren't super familiar with the colors (like me). I made it a tooltip just like the 'Occurrences' one.

I also moved both tooltips to the left side because I noticed they were being cut-off at the edge of the page or obstructed by the neighboring card. If there's a better way to deal with that I'm happy to change it.

**After: Showing level 2 tooltip**
![image](https://github.com/presciencelabs/tabitha-ontology/assets/152427351/18dac3fd-76de-4668-b48e-3d7d184bb456)

**Before: 'Occurrences' tooltip being cut off on the right**
![image](https://github.com/presciencelabs/tabitha-ontology/assets/152427351/8dd7deb6-4c0f-4a84-8735-e2da77d86190)

**After: 'Occurrences' tooltip now showing on the left**
![image](https://github.com/presciencelabs/tabitha-ontology/assets/152427351/f6b00700-8c40-49d5-8b4c-c01f3a863776)