### PR TITLE
Use new data from the targets api

### DIFF
--- a/src/lib/examples/Examples.svelte
+++ b/src/lib/examples/Examples.svelte
@@ -59,14 +59,9 @@
 
 				<section class="collapse-content">
 					{#if retrieval_queue.includes(i)}
-						<SourceData {reference} />
+						<TargetData {reference} />
 
-						<h4>
-							Generated English text
-						</h4>
-						<p>
-							<TargetData {reference} />
-						</p>
+						<SourceData {reference} />
 					{/if}
 				</section>
 			</details>

--- a/src/lib/examples/SemanticEncoding.svelte
+++ b/src/lib/examples/SemanticEncoding.svelte
@@ -113,10 +113,5 @@
 
 </script>
 
-<h4 class="flex justify-between">
-	Semantic encoding (Phase 2)
-</h4>
-<p>
-	<!--TODO display clause/phrase boundaries differently, and show (some?) features on hover -->
-	{simple_encoding}
-</p>
+<!--TODO display clause/phrase boundaries differently, and show (some?) features on hover -->
+{simple_encoding}

--- a/src/lib/examples/SourceData.svelte
+++ b/src/lib/examples/SourceData.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { PUBLIC_SOURCES_API_HOST } from '$env/static/public'
-	import { SemanticEncoding } from '$lib'
+	import { SemanticEncoding } from '$lib/examples'
 	import Icon from '@iconify/svelte'
 
 	/** @type {Reference} */
@@ -28,11 +28,20 @@
 </script>
 
 {#await get_source_data(reference)}
-	<span class="loading loading-spinner text-warning"></span>
-	getting the source data...
+	<p>
+		<span class="loading loading-spinner text-warning"></span>
+		getting the source data...
+	</p>
 {:then source}
 	<h4 class="flex justify-between">
-		Phase 1 encoding
+		Phase 1 encoding (may be out of date)
+	</h4>
+	<p>
+		{source.phase_1_encoding}
+	</p>
+
+	<h4 class="flex justify-between">
+		Semantic encoding (Phase 2)
 
 		<a href={get_sources_url(reference)} target="_blank" class="link link-accent link-hover text-sm flex items-end">
 			all source details
@@ -40,8 +49,6 @@
 		</a>
 	</h4>
 	<p>
-		{source.phase_1_encoding}
+		<SemanticEncoding semantic_encoding={source.semantic_encoding} />
 	</p>
-
-	<SemanticEncoding semantic_encoding={source.semantic_encoding} />
 {/await}

--- a/src/lib/examples/TargetData.svelte
+++ b/src/lib/examples/TargetData.svelte
@@ -7,18 +7,31 @@
 	/**
 	 * @param {Reference} reference
 	 *
-	 * @returns {Promise<string>}
+	 * @returns {Promise<TargetTextResult>}
 	 */
 	async function get_target_data({ id_primary, id_secondary, id_tertiary }) {
 		const response = await fetch(`${PUBLIC_TARGETS_API_HOST}/English/${id_primary}/${id_secondary}/${id_tertiary}`)
 
-		return await response.json()
+		// Show the Unchurched Adults if available, because it's usually the most up-to-date.
+		// Otherwise, default to the first audience with text
+		/** @type {TargetTextResult[]}*/
+		const texts = await response.json()
+		return texts.find(text => text.audience === 'Unchurched Adults')
+			|| texts.find(text => text.text)
+			|| { text: '--', audience: 'none saved yet...' }
 	}
 </script>
 
 {#await get_target_data(reference)}
-	<span class="loading loading-spinner text-warning"></span>
-	getting the target data...
-{:then text}
-	{text || '–'}
+	<p>
+		<span class="loading loading-spinner text-warning"></span>
+		getting the target data...
+	</p>
+{:then { text, audience }}
+	<h4>
+		Generated English text ({audience})
+	</h4>
+	<p>
+		{text}
+	</p>
 {/await}

--- a/src/lib/examples/index.js
+++ b/src/lib/examples/index.js
@@ -4,6 +4,7 @@ import ExampleSummary from './ExampleSummary.svelte'
 import Filters from './Filters.svelte'
 import SourceData from './SourceData.svelte'
 import TargetData from './TargetData.svelte'
+import SemanticEncoding from './SemanticEncoding.svelte'
 
 export {
 	by_book_order,
@@ -13,4 +14,5 @@ export {
 	Filters,
 	SourceData,
 	TargetData,
+	SemanticEncoding,
 }

--- a/src/lib/examples/types.d.ts
+++ b/src/lib/examples/types.d.ts
@@ -4,3 +4,8 @@ type Option = ContextArgumentValue
 type Options = Set<Option>
 type FilterMap = Map<ContextArgumentName, Options>
 type FilterRulesMap = Map<Concept['part_of_speech'], FilterMap>
+
+type TargetTextResult = {
+	text: string
+	audience: string
+}

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -6,7 +6,6 @@ import { Examples } from './examples'
 import Level from './Level.svelte'
 import Occurrences from './Occurrences.svelte'
 import Search from './Search.svelte'
-import SemanticEncoding from './SemanticEncoding.svelte'
 import Table from './Table.svelte'
 
 export {
@@ -18,7 +17,6 @@ export {
 	Level,
 	Occurrences,
 	Search,
-	SemanticEncoding,
 	SummaryCard,
 	Table,
 }


### PR DESCRIPTION
The targets API was updated to return text from each available audience. This PR accounts for that change, and displays the Unchurched Adults text as the default, since it usually matches the source the best.

Relates to https://github.com/presciencelabs/tabitha-databases/pull/15 and https://github.com/presciencelabs/tabitha-targets/pull/19

Before:
![image](https://github.com/user-attachments/assets/dcc507a0-207e-416c-a105-6e0a65b5184b)

After:
![image](https://github.com/user-attachments/assets/9f38441c-f9f1-458a-9e47-4f13da35fa74)

![image](https://github.com/user-attachments/assets/b95b411b-6553-4191-a58c-376ba943ea65)
