### PR TITLE
Simple status alert in expanded SourceData

### DIFF
--- a/src/lib/examples/SourceData.svelte
+++ b/src/lib/examples/SourceData.svelte
@@ -51,6 +51,14 @@
 			<Icon icon="fe:link-external" class="h-6 w-6" />
 		</a>
 	</h4>
+
+	{#if source.status !== 'Ready to Translate'}
+		<div role="alert" class="alert alert-warning alert-soft">
+			<Icon icon="mdi:alert-outline" class="h-6 w-6" />
+			<span>Source data for this verse is still being reviewed, so this usage may not be accurate.</span>
+		</div>
+	{/if}
+
 	<p>
 		<SourceEntities source_entities={source.parsed_semantic_encoding} {selected_concept} />
 	</p>

--- a/src/lib/examples/types.d.ts
+++ b/src/lib/examples/types.d.ts
@@ -18,8 +18,11 @@ type SourceData = {
 	phase_1_encoding: string
 	semantic_encoding: string
 	parsed_semantic_encoding: SourceEntity[]
+	status: SourceStatus
 	notes: string
 }
+
+type SourceStatus = 'Not Started' | 'Initial Analysis in Progress' | 'Initial Analysis Complete' | 'Final Review in Progress' | 'Ready to Translate'
 
 type SourceEntity = {
 	category: CategoryName


### PR DESCRIPTION
To start, simply show a status warning when the user clicks on an example.

<img width="1040" height="566" alt="image" src="https://github.com/user-attachments/assets/d0f162ab-81df-4fda-8bbb-cc6907edc59d" />

In future we would like to add a warning on the example summary itself, but that will require some extra design and improved efficiency. The above is a good place to start.


