### PR TITLE
Example status warning

### DIFF
--- a/src/lib/examples/ExampleSummary.svelte
+++ b/src/lib/examples/ExampleSummary.svelte
@@ -1,9 +1,14 @@
 <script>
+	import Icon from '@iconify/svelte'
+
 	/** @type { Reference } */
 	export let reference
 
 	/** @type { ContextArguments } */
 	export let context
+
+	/** @type { SourceStatus } */
+	export let book_status
 
 	$: ({ id_primary, id_secondary, id_tertiary } = reference)
 </script>
@@ -11,6 +16,17 @@
 <section class="flex">
 	<span class="min-w-1/6 w-1/6 flex-shrink-0 whitespace-nowrap">
 		{id_primary} {id_secondary}:{id_tertiary}
+
+		{#if book_status !== 'Ready to Translate'}
+			<div class="dropdown dropdown-hover">
+				<div role="button" class="-mb-1 text-warning">
+					<Icon icon="mdi:alert-outline" class="h-6 w-6" />
+				</div>
+				<div class="dropdown-content bg-warning text-warning-content text-sm rounded-box z-1 p-2 shadow-sm">
+					Source data for this book is still being reviewed, so this usage may not be accurate.
+				</div>
+			</div>
+		{/if}
 	</span>
 
 	<aside class="flex flex-wrap gap-y-2">

--- a/src/lib/examples/ExampleSummary.svelte
+++ b/src/lib/examples/ExampleSummary.svelte
@@ -20,7 +20,7 @@
 		{#if book_status !== 'Ready to Translate'}
 			<div class="dropdown dropdown-hover">
 				<div role="button" class="-mb-1 text-warning">
-					<Icon icon="mdi:alert-outline" class="h-6 w-6" />
+					<Icon icon="mdi:alert-outline" class="h-5 w-5" />
 				</div>
 				<div class="dropdown-content bg-warning text-warning-content text-sm rounded-box z-1 p-2 shadow-sm">
 					Source data for this book is still being reviewed, so this usage may not be accurate.

--- a/src/lib/examples/Examples.svelte
+++ b/src/lib/examples/Examples.svelte
@@ -51,10 +51,10 @@
 	{:then}
 		<Filters {concept} examples={all_examples} on:data-filtered={({ detail }) => filtered_examples = detail} />
 
-		{#each filtered_examples.sort(by_book_order).slice(0, MAX_EXAMPLES_DISPLAYED) as { reference, context }, i}
+		{#each filtered_examples.sort(by_book_order).slice(0, MAX_EXAMPLES_DISPLAYED) as { reference, context, book_status }, i}
 			<details on:toggle={event => handle_queue(event, i)} transition:fade={FADE_CHARACTERISTICS} class="collapse collapse-arrow bg-base-100 overflow-visible">
 				<summary class="collapse-title border border-base-200">
-					<ExampleSummary {reference} {context} />
+					<ExampleSummary {reference} {context} {book_status} />
 				</summary>
 
 				<section class="collapse-content">

--- a/src/lib/examples/SourceData.svelte
+++ b/src/lib/examples/SourceData.svelte
@@ -59,7 +59,7 @@
 		</div>
 	{/if}
 
-	<p>
+	<div class="my-2">
 		<SourceEntities source_entities={source.parsed_semantic_encoding} {selected_concept} />
-	</p>
+	</div>
 {/await}

--- a/src/lib/examples/types.d.ts
+++ b/src/lib/examples/types.d.ts
@@ -48,3 +48,7 @@ type EntityFeature = {
 	name: FeatureName,
 	value: FeatureValue,
 }
+
+type StatusApiResult = {
+	status: SourceStatus
+}

--- a/src/lib/server/index.d.ts
+++ b/src/lib/server/index.d.ts
@@ -50,14 +50,15 @@ type CuratedExample = {
 type DbRowExample = {
 	ref_type: string
 	ref_id_primary: string
-	ref_id_secondary: string
-	ref_id_tertiary: string
+	ref_id_secondary: number
+	ref_id_tertiary: number
 	context_json: string
 }
 
 type Example = {
 	reference: Reference
 	context: ContextArguments
+	book_status: SourceStatus
 }
 
 type ContextArgumentName = string

--- a/src/lib/server/ontology.js
+++ b/src/lib/server/ontology.js
@@ -162,16 +162,20 @@ export const get_examples = db => async (concept, part_of_speech, source) => {
 
 	return results.map(normalize_results)
 
-	/** @param {DbRowExample} arg */
+	/**
+	 * @param {DbRowExample} arg
+	 * @return {Example}
+	*/
 	function normalize_results({ ref_type, ref_id_primary, ref_id_secondary, ref_id_tertiary, context_json }) {
 		return {
 			reference: {
 				type: ref_type,
 				id_primary: ref_id_primary,
-				id_secondary: ref_id_secondary,
-				id_tertiary: ref_id_tertiary,
+				id_secondary: ref_id_secondary.toString(),
+				id_tertiary: ref_id_tertiary.toString(),
 			},
 			context: JSON.parse(context_json),
+			book_status: 'Ready to Translate',	// this will be updated after the API call to Sources
 		}
 	}
 }

--- a/src/routes/examples/+server.js
+++ b/src/routes/examples/+server.js
@@ -1,3 +1,4 @@
+import { PUBLIC_SOURCES_API_HOST } from '$env/static/public'
 import { json, error } from '@sveltejs/kit'
 import { get_examples } from '$lib/server/ontology'
 
@@ -8,8 +9,9 @@ export async function GET({ url: { searchParams }, locals: { db_ontology } }) {
 	const source = searchParams.get('source') ?? ''
 
 	const examples = await get_examples(db_ontology)(concept, part_of_speech, source)
+	const examples_with_status = await fetch_statuses_by_book(examples)
 
-	return response(examples)
+	return response(examples_with_status)
 
 	/** @param {any} result  */
 	function response(result) {
@@ -21,4 +23,35 @@ export async function GET({ url: { searchParams }, locals: { db_ontology } }) {
 			headers: THREE_HOUR_CACHE,
 		})
 	}
+}
+
+/**
+ * @param {Example[]} examples 
+ * @returns {Promise<Example[]>}
+ */
+async function fetch_statuses_by_book(examples) {
+	const book_refs = Array.from(new Set(examples.map(({ reference }) => reference.id_primary)))
+
+	// Fetch the status for each book to reduce the number of API calls compared to checking each verse.
+	// Also rely on caching to reduce the time it takes to fetch the statuses.
+	// Without the caching, the whole process can take ~10 seconds.
+
+	/** @type {[string, SourceStatus][]} */
+	const book_statuses = await Promise.all(book_refs.map(async (book) => {
+		const response = await fetch(`${PUBLIC_SOURCES_API_HOST}/lookup/status/Bible/${book}`)
+		if (!response.ok) {
+			// just ignore the status if the API call fails
+			return [book, 'Ready to Translate']
+		}
+		/** @type {StatusApiResult} */
+		const { status } = await response.json()
+		return [book, status]
+	}))
+
+	const status_map = new Map(book_statuses)
+
+	return examples.map(example => {
+		const book_status = status_map.get(example.reference.id_primary) ?? 'Initial Analysis in Progress'
+		return { ...example, book_status }
+	})
 }

--- a/src/routes/examples/+server.js
+++ b/src/routes/examples/+server.js
@@ -37,7 +37,7 @@ async function fetch_statuses_by_book(examples) {
 	// Without the caching, the whole process can take ~10 seconds.
 
 	/** @type {[string, SourceStatus][]} */
-	const book_statuses = await Promise.all(book_refs.map(async (book) => {
+	const book_statuses = await Promise.all(book_refs.map(async book => {
 		const response = await fetch(`${PUBLIC_SOURCES_API_HOST}/lookup/status/Bible/${book}`)
 		if (!response.ok) {
 			// just ignore the status if the API call fails


### PR DESCRIPTION
<img width="1230" height="352" alt="image" src="https://github.com/user-attachments/assets/620dec65-f014-436e-a201-4facfb1d4c0e" />

The statuses are fetched server-side in the Examples API call, and only the status of the books are retrieved, in order to reduce the number of status API calls. I think this is fine on the summary level.

Also fixed a typing issue which caused problems with the status SQL.