### PR TITLE
Fix curated example UI

### DIFF
--- a/src/lib/app.css
+++ b/src/lib/app.css
@@ -36,3 +36,19 @@
 		winter,
 		wireframe;
 }
+
+.entity-NP, .entity-N {
+	color: #aa795d;
+}
+.entity-VP, .entity-V {
+	color: #507a8b;
+}
+.entity-AdjP, .entity-Adj {
+	color: #548159;
+}
+.entity-AdvP, .entity-Adv {
+	color: #86CBA7;
+}
+.entity-Adp {
+	color: #86657C;
+}

--- a/src/lib/card/DetailedCard.svelte
+++ b/src/lib/card/DetailedCard.svelte
@@ -6,6 +6,7 @@
 	import { Category } from './categorization'
 	import { onMount } from 'svelte'
 	import { CONCEPT_FILTERS } from '$lib/filters'
+	import SimplifiedEntities from '$lib/examples/curated_examples/SimplifiedEntities.svelte'
 
 	/** @type {Concept} */
 	export let concept
@@ -44,7 +45,7 @@
 					</section>
 				{/if}
 
-				{#if CONCEPT_FILTERS.IS_IN_ONTOLOGY(concept)}
+				{#if curated_examples.length > 0 && CONCEPT_FILTERS.IS_IN_ONTOLOGY(concept)}
 					<section class="prose mt-4 max-w-none">
 						<Details colors="bg-base-200">
 							<span slot="summary">
@@ -61,22 +62,10 @@
 										{reference.id_secondary}:{reference.id_tertiary})
 									</cite>
 
-									<footer class="mt-4 flex justify-around bg-base-100">
-										{#each encoding as { part_of_speech, role, word }}
-											<span class="flex flex-col items-center py-2">
-												<span class="mb-1 not-italic tracking-widest text-base-content">
-													{word}
-												</span>
-												<small class="font-mono text-xs text-base-content">
-													{part_of_speech}
-													{role ? `[${role}]` : ''}
-												</small>
-											</span>
-										{/each}
+									<footer class="mt-4 px-4 flex gap-2 justify-left bg-base-100">
+										<SimplifiedEntities entities={encoding} />
 									</footer>
 								</blockquote>
-							{:else}
-								–
 							{/each}
 						</Details>
 					</section>

--- a/src/lib/examples/curated_examples/SimplifiedEntities.svelte
+++ b/src/lib/examples/curated_examples/SimplifiedEntities.svelte
@@ -1,0 +1,100 @@
+<script>
+	/** @type {SimplifiedSemanticEncoding} */
+	export let entities
+
+	/** @type {Record<string, string>}*/
+	const boundary_char_map = {
+		'NP': '(',
+		'VP': '(',
+		'AdjP': '(',
+		'AdvP': '(',
+		'Phrase end': ')',
+		'Clause': '[',
+		'Clause end': ']',
+	}
+
+	/** @type {Record<string, string>}*/
+	const label_map = {
+		'NP': 'NP',
+		'VP': 'VP',
+		'AdjP': 'AdjP',
+		'AdvP': 'AdvP',
+		// for 'Proposition' - verb clause arguments are called 'Patient/Agent Propositions'
+		'Clause': 'Prop',
+	}
+
+	/**
+	 * Find the parent boundary, or if the entity is a boundary, return itself
+	 * @param {number} index
+	*/
+	function find_closest_boundary(index) {
+		let inner_level = 0
+		for (let j = index; j >= 0; j--) {
+			const entity = entities[j]
+			if (is_boundary_start(entity)) {
+				if (inner_level === 0) {
+					return entity
+				} else {
+					inner_level -= 1
+				}
+			} else if (is_boundary_end(entity) && j !== index) {
+				// skip over any phrases/clauses nested within this one
+				inner_level += 1
+			}
+		}
+		console.error('Unexpected entity structure with index:', index)
+		return entities[index]
+	}
+
+	/**
+	 * @param {number} index
+	*/
+	function get_style_class(index) {
+		const boundary_category = find_closest_boundary(index).category
+		return `entity-${boundary_category}`
+	}
+
+	/**
+	 * @param {SimplifiedEncodingEntity} entity
+	 */
+	function is_boundary_start(entity) {
+		return entity.category in label_map
+	}
+
+	/**
+	 * @param {SimplifiedEncodingEntity} entity
+	 */
+	function is_boundary_end(entity) {
+		return entity.category.endsWith('end')
+	}
+</script>
+
+{#each entities as entity, i}
+	{@const boundary_char = boundary_char_map[entity.category]}
+	{@const label = entity.word || label_map[entity.category] || ''}
+	{@const style_class = get_style_class(i)}
+	
+	<span class="mb-1 py-2 not-italic text-base-content flex items-center">
+		{#if boundary_char}
+			<span class="text-3xl font-thin {style_class}">
+				{boundary_char}
+			</span>
+		{/if}
+
+		{#if entity.feature}
+			<span class="text-md pt-2 font-medium {style_class}">
+				{label}-{entity.feature.value}
+			</span>
+		{:else}
+			<span class="text-md pt-2 font-normal {style_class}">
+				{label}
+			</span>
+		{/if}
+	</span>
+{/each}
+
+<style>
+	.entity-Clause {
+		opacity: 0.6
+	}
+</style>

--- a/src/lib/examples/semantic_encoding/BoundaryEnd.svelte
+++ b/src/lib/examples/semantic_encoding/BoundaryEnd.svelte
@@ -1,8 +1,15 @@
 <script>
-	import Punctuation from './Punctuation.svelte'
-
 	/** @type {SourceEntity} */
 	export let source_entity
+	
+	/** @type {Record<string, string>}*/
+	const boundary_size_map = {
+		'}': 'text-2xl',
+		']': 'text-xl',
+		')': 'text-xl',
+	}
 </script>
 
-<Punctuation {source_entity} />
+<span class="{boundary_size_map[source_entity.value]} font-thin pe-1">
+	{']'}
+</span>

--- a/src/lib/examples/semantic_encoding/BoundaryStart.svelte
+++ b/src/lib/examples/semantic_encoding/BoundaryStart.svelte
@@ -3,11 +3,18 @@
 
 	/** @type {SourceEntity} */
 	export let source_entity
+
+	/** @type {Record<string, string>}*/
+	const boundary_size_map = {
+		'{': 'text-2xl',
+		'[': 'text-xl',
+		'(': 'text-xl',
+	}
 </script>
 
 <span class="inline-flex pe-1 tracking-widest">
-	<span class="text-lg font-thin">
-		{source_entity.value}
+	<span class="{boundary_size_map[source_entity.value]} font-thin">
+		{'['}
 	</span>
 	<Features {source_entity} classes={'self-center'}>
 		<span class="text-sm tracking-tight">

--- a/src/lib/examples/semantic_encoding/SourceEntities.svelte
+++ b/src/lib/examples/semantic_encoding/SourceEntities.svelte
@@ -26,18 +26,56 @@
 
 	/** @type {[(entity: SourceEntity) => boolean, typeof Word][]}*/
 	const component_filters = [
-		[({ value }) => ['{', '[', '('].includes(value), BoundaryStart],
-		[({ value }) => ['}', ']', ')'].includes(value), BoundaryEnd],
+		[is_boundary_start, BoundaryStart],
+		[is_boundary_end, BoundaryEnd],
 		[({ concept }) => !!concept, Word],
 		[() => true, Punctuation],
 	]
+
+	/**
+	 * @param {SourceEntity[]} entities
+	 * @param {number} index
+	 */
+	function get_parent_category(entities, index) {
+		let inner_level = 0
+		for (let j = index-1; j >= 0; j--) {
+			const entity = entities[j]
+			if (is_boundary_start(entity)) {
+				if (inner_level === 0) {
+					return entity.category_abbr
+				} else {
+					inner_level -= 1
+				}
+			} else if (is_boundary_end(entity)) {
+				// skip over any phrases/clauses nested within this one
+				inner_level += 1
+			}
+		}
+		return ''
+	}
+
+	/**
+	 * @param {SourceEntity} entity
+	 */
+	function is_boundary_start(entity) {
+		return ['{', '[', '('].includes(entity.value)
+	}
+
+	/**
+	 * @param {SourceEntity} entity
+	 */
+	function is_boundary_end(entity) {
+		return ['}', ']', ')'].includes(entity.value)
+	}
 </script>
 
 {#each main_clauses as main_clause}
-	<div class="hover:bg-base-200">
-		{#each main_clause as source_entity}
+	<div class="hover:bg-base-200 flex flex-wrap items-center">
+		{#each main_clause as source_entity, i}
 			{@const component = component_filters.find(([filter]) => filter(source_entity))?.[1]}
-			<svelte:component this={component} {source_entity} {selected_concept} />
+			<span class="entity-{source_entity.category_abbr || get_parent_category(main_clause, i)}">
+				<svelte:component this={component} {source_entity} {selected_concept} />
+			</span>
 		{/each}
 	</div>
 {/each}

--- a/src/lib/lookups.js
+++ b/src/lib/lookups.js
@@ -285,3 +285,35 @@ export const levels = new Map([
 ])
 
 export const parts_of_speech = ['Noun', 'Verb', 'Adjective', 'Adverb', 'Adposition', 'Conjunction', 'Particle', 'Phrasal']
+
+export const curated_example_category_codes = {
+	'(NP': 'NP',
+	'(VP': 'VP',
+	'(AP': 'AdjP',
+	'(aP': 'AdvP',
+	'[': 'Clause',
+	')': 'Phrase end',
+	']': 'Clause end',
+}
+
+/** @type {Record<string, Record<string, string>>} */
+export const curated_example_feature_codes = {
+	'NP': {
+		'A': 'Agent',
+		'P': 'Patient',
+		'd': 'Destination',
+		's': 'Source',
+		'S': 'State',
+		'I': 'Instrument',
+		'B': 'Beneficiary',
+		'D': 'Addressee',
+	},
+	'AdjP': {
+		'A': 'Attributive',
+		'P': 'Predicative',
+	},
+	'Clause': {
+		'A': 'Agent',
+		'P': 'Patient',
+	},
+}

--- a/src/lib/server/index.d.ts
+++ b/src/lib/server/index.d.ts
@@ -72,13 +72,18 @@ type Reference = {
 	id_tertiary: string
 }
 
-type SimplifiedEncodingPhrase = {
-	part_of_speech: string
-	role: string
-	word: string
+type SimplifiedEncodingEntity = {
+	category: CategoryName
+	word: string | undefined
+	feature: SimpleEncodingFeature | undefined
 }
 
-type SimplifiedSemanticEncoding =  SimplifiedEncodingPhrase[]
+type SimpleEncodingFeature = {
+	code: string
+	value: string
+}
+
+type SimplifiedSemanticEncoding =  SimplifiedEncodingEntity[]
 
 type Permission = 'PROTECTED_ACCESS' | 'ADD_CONCEPT' | 'UPDATE_CONCEPT' | 'DELETE_CONCEPT'
 

--- a/src/lib/server/semantic_search.ts
+++ b/src/lib/server/semantic_search.ts
@@ -51,9 +51,9 @@ export async function find_related_concepts(db: D1Database, search_term: string)
 				'items': {
 					'type': 'string',
 					'description': 'The concept identifier.',
-				}
-			}
-		}
+				},
+			},
+		},
 	})
 
 	const output = response.text?.length ? JSON.parse(response.text) as string[] : []

--- a/src/lib/transformers.js
+++ b/src/lib/transformers.js
@@ -1,4 +1,4 @@
-import { semantic_category, sources, theta_grid, usage_info } from '$lib/lookups'
+import { curated_example_category_codes, curated_example_feature_codes, semantic_category, sources, theta_grid, usage_info } from '$lib/lookups'
 
 /**
  * @param {string} curated_examples_raw "4,2,2,2|(NPp|baby|)|(VP|be|)|(APP|beautiful|)|~The baby was beautiful.\n4,17,2,2|(NPp|Xerxes|)|(VP|search|)|(NPP|(APA|beautiful|)|virgin|)|~Xerxes searched for a beautiful virgin.\n4,40,6,29|(NPp|clothes|(NPN|of|flower|)|)|(VP|be|)|(APP|beautiful|(NPN|clothes|(NPN|of|Solomon|)|)|)|~The flower's clothers are more beautiful than Solomon's clothes.\n"
@@ -7,9 +7,14 @@ import { semantic_category, sources, theta_grid, usage_info } from '$lib/lookups
  */
 export function transform_curated_examples(curated_examples_raw) {
 	const encoded_examples = curated_examples_raw.split('\n').filter(field => !!field)
-	// 4,2,2,2|(NPp|baby|)|(VP|be|)|(APP|beautiful|)|~The baby was beautiful.
-	// 4,17,2,2|(NPp|Xerxes|)|(VP|search|)|(NPP|(APA|beautiful|)|virgin|)|~Xerxes searched for a beautiful virgin.
-	// 4,40,6,29|(NPp|clothes|(NPN|of|flower|)|)|(VP|be|)|(APP|beautiful|(NPN|clothes|(NPN|of|Solomon|)|)|)|~The flower's clothes are more beautiful than Solomon's clothes.
+	// beautiful-A:
+	//   4,2,2,2|(NPA|baby|)|(VP|be|)|(APP|beautiful|)|~The baby was beautiful.
+	//   4,17,2,2|(NPA|Xerxes|)|(VP|search|)|(NPP|(APA|beautiful|)|virgin|)|~Xerxes searched for a beautiful virgin.
+	//   4,40,6,29|(NPA|clothes|(NPN|of|flower|)|)|(VP|be|)|(APP|beautiful|(NPN|clothes|(NPN|of|Solomon|)|)|)|~The flower's clothes are more beautiful than Solomon's clothes.
+	// be-V:
+	//   6,8,1,67|[A|(NPA|John|)|(VP|read|)|(NPP|book|)|]|(VP|be|)|(APP|true|)|~It is true that John read that book.
+	//   4,41,14,21|[A|(NPA|man|)|(VP|born|)|(aP|never|)|]|(VP|be|)|(APP|good|)|(NPB|man|)|~It's better for that man that he was never born.
+
 	return encoded_examples.map(decode)
 
 	/**
@@ -18,45 +23,63 @@ export function transform_curated_examples(curated_examples_raw) {
 	 * @returns {CuratedExample}
 	 */
 	function decode(encoded_example) {
-		const encoded_reference = encoded_example.split('|')[0] // '4,2,2,2'
-		const simplified_semantic_encoding = encoded_example.match(/\|(.*)\|~/)?.[1] || '' // (NPp|baby|)|(VP|be|)|(APP|beautiful|)
+		const parts = encoded_example.split('|')
+		const encoded_reference = parts[0] // '4,2,2,2'
+		const encoded_entities = parts.slice(1, -1) // ['(NPA', 'baby', ')', '(VP', 'be', ')', '(APP', 'beautiful', ')']
+		const sentence = parts.at(-1)?.slice(1) || '' // The baby was beautiful. (ignore the '~')
 
 		return {
 			reference: decode_reference(encoded_reference),
-			encoding: decode_simplified_encoding(simplified_semantic_encoding),
-			sentence: encoded_example.split('~')[1], // The baby was beautiful.
+			encoding: decode_simplified_encoding(encoded_entities),
+			sentence,
 		}
 
 		/**
-		 * @param {string} simplified_semantic_encoding '(NPp|baby|)|(VP|be|)|(APP|beautiful|)'
+		 * @param {string[]} encoded_entities ['(NPA', 'baby', ')', '(VP', 'be', ')', '(APP', 'beautiful', ')']
 		 *
 		 * @returns {SimplifiedSemanticEncoding}
 		 */
-		function decode_simplified_encoding(simplified_semantic_encoding) {
-			const encoded_phrases = simplified_semantic_encoding.match(/\([^)]+\|[^)]+\)/g) || [] // ['(NPp|baby|)', '(VP|be|)', '(APP|beautiful|)']
+		function decode_simplified_encoding(encoded_entities) {
+			const entities = encoded_entities.map(decode_entity)
 
-			const argument_phrases = encoded_phrases.map(decode_phrase)
-
-			return argument_phrases
+			return entities
 
 			/**
-			 * @param {string} encoded_phrase '(NPp|baby|)'
+			 * @param {string} encoded_entity '(NPp', 'baby', ')', etc
 			 *
-			 * @returns {SimplifiedEncodingPhrase}
+			 * @returns {SimplifiedEncodingEntity}
 			 */
-			function decode_phrase(encoded_phrase) {
-				const [type, word] = encoded_phrase.replace(/[()]/g, '').split('|') // ['NPp', 'baby']
-				const part_of_speech = `${type[0]}${type[1]}` //'NP' or 'VP' or 'AP'
-				const role = type[2] || '' // 'p' or '' or 'P'
+			function decode_entity(encoded_entity) {
+				// (NPA => { category: 'NP', value: '(', feature: { code: 'A', value: 'Most Agent-like' } }
+				// baby => { category: 'value', value: 'baby', feature: undefined }
+				// ) => { category: 'Phrase end', value: ')', feature: undefined }
+				// (VP => { category: 'VP', value: '(', feature: undefined }
+				// (APP => { category: 'AdjP', value: '(', feature: { code: 'P', value: 'Predicative' } }
+				// [A => { category: 'Clause', value: '[', feature: { code: 'A', value: 'Agent' } }
 
-				// (NPp|baby|) => { part_of_speech: 'NP', role: 'p', word: 'baby' }
-				// (VP|be|) => { part_of_speech: 'VP', role: '', word: 'be' }
-				// (APP|beautiful|) => { part_of_speech: 'AP', role: 'P', word: 'beautiful' }
+				const category = Object.entries(curated_example_category_codes).find(([code]) => encoded_entity.startsWith(code))?.[1] || 'Word'
+				const feature_code = encoded_entity.at(-1) || ''
+				const feature_value = curated_example_feature_codes[category]?.[feature_code]
 				return {
-					part_of_speech,
-					role,
-					word,
+					category,
+					word: category === 'Word' ? encoded_entity : undefined,
+					feature: feature_value ? { code: feature_code, value: feature_value } : undefined
 				}
+			}
+
+			/**
+			 * @param {string} category 
+			 * @param {string} encoded
+			 */
+			function create_entity_display(category, encoded) {
+				if (category === 'Clause') {
+					// for 'Proposition' - verb clause arguments are called 'Patient/Agent Propositions'
+					return '[Prop'
+				}
+				if (['NP', 'VP', 'AdjP', 'AdvP'].includes(category)) {
+					return `(${category}`
+				}
+				return encoded
 			}
 		}
 	}

--- a/src/lib/transformers.js
+++ b/src/lib/transformers.js
@@ -63,23 +63,8 @@ export function transform_curated_examples(curated_examples_raw) {
 				return {
 					category,
 					word: category === 'Word' ? encoded_entity : undefined,
-					feature: feature_value ? { code: feature_code, value: feature_value } : undefined
+					feature: feature_value ? { code: feature_code, value: feature_value } : undefined,
 				}
-			}
-
-			/**
-			 * @param {string} category 
-			 * @param {string} encoded
-			 */
-			function create_entity_display(category, encoded) {
-				if (category === 'Clause') {
-					// for 'Proposition' - verb clause arguments are called 'Patient/Agent Propositions'
-					return '[Prop'
-				}
-				if (['NP', 'VP', 'AdjP', 'AdvP'].includes(category)) {
-					return `(${category}`
-				}
-				return encoded
 			}
 		}
 	}


### PR DESCRIPTION
Properly handle the curated examples and update the display. I think curated examples are still valuable and here to stay, so I wanted to get it working. The updated display will also be used on the concept CRUD pages.

<img width="1693" height="786" alt="image" src="https://github.com/user-attachments/assets/099a9738-6e2f-41f2-99cb-52665a2b5505" />
<img width="1677" height="628" alt="image" src="https://github.com/user-attachments/assets/b91fe468-6d08-4b10-9bb6-2eed1fe71880" />
<img width="1684" height="896" alt="image" src="https://github.com/user-attachments/assets/678fed2c-1b2b-443b-a4ad-38138db9b3fc" />

I used the same colors as within the Sources app for visual consistency. I also updated the source encoding display within the Examples to also use the same colors.

<img width="1608" height="518" alt="image" src="https://github.com/user-attachments/assets/3c1e1ae6-d3c5-42bf-82c8-c3a8fbc0a51c" />
