### PR TITLE
Semantic Search improvements

### DIFF
--- a/src/lib/Search.svelte
+++ b/src/lib/Search.svelte
@@ -29,6 +29,10 @@
 	}
 
 	function store_scope() {
+		// don't store the 'semantic' scope to avoid accidental uses
+		if ($scope === 'semantic') {
+			return
+		}
 		localStorage.setItem('search_scope', $scope)
 
 		console.info('search scope saved: ', $scope)
@@ -50,7 +54,7 @@
 			{/each}
 		</select>
 
-		<select name="scope" bind:value={$scope} on:change={store_scope} class="select select-primary select-lg join-item">
+		<select name="scope" bind:value={$scope} on:change={store_scope} class="select select-primary select-lg join-item {$scope === 'semantic' ? 'border-6 border-error' : ''}">
 			<option value="stems">Stems only</option>
 			<option value="glosses">Glosses only</option>
 			<option value="all">Stems and Glosses</option>

--- a/src/lib/server/semantic_search.ts
+++ b/src/lib/server/semantic_search.ts
@@ -6,13 +6,21 @@ import type { D1Database } from '@cloudflare/workers-types'
 export async function find_related_concepts(db: D1Database, search_term: string): Promise<Concept[]> {
 	const all_concepts = await get_all_concepts(db)
 
+	// check the cache
+	const cached_results = get_from_cache(search_term)
+	if (cached_results) {
+		return cached_results.map(key => all_concepts.find(c => key === concept_key(c))!)
+	}
+
 	// These filters currently result in ~3800 concepts getting sent to the LLM, down from ~6380
 	const concept_filters: ((c: Concept) => boolean)[] = [
 		// don't bother including whole numbers, they just use up tokens
 		// leave decimal numbers though, so things like 'tenth' can relate to '.1'
 		c => c.gloss.includes('number') && !!c.stem.match(/^\d/),
 		// don't bother including proper names, unless one of the geographical ones like mount-Horeb, city-David, etc. Unsure about this one
-		c => c.gloss.startsWith('(proper name)') && !c.stem.match(/^(?:sea-|mount-|valley-|river-|desert-|city-|cave-|feast-|gate-)/i),
+		c => c.gloss.startsWith('(proper name)') /*&& !c.stem.match(/^(?:sea-|mount-|valley-|river-|desert-|city-|cave-|feast-|gate-)/i)*/,
+		// don't include dates and times other than '12PM' so it can relate to 'noon'
+		c => !!c.stem.match(/\d(?:BC|AD|PM|AM)$/) && c.stem !== '12PM',
 		// don't include concepts that are going to be deleted
 		c => c.gloss.includes('DELETE'),
 		// don't include the concepts that are exactly the search term (handled separately and would be redundant)
@@ -21,6 +29,7 @@ export async function find_related_concepts(db: D1Database, search_term: string)
 		c => c.stem === search_term,
 	]
 
+	// Note that currently the input is about 73800 tokens, and sometimes triggers 20000-50000 tokens of implicit cache
 	const input_data = {
 		concepts: all_concepts.filter(c => !concept_filters.some(f => f(c))).map(transform_concept),
 		search_term,
@@ -57,6 +66,10 @@ export async function find_related_concepts(db: D1Database, search_term: string)
 	})
 
 	const output = response.text?.length ? JSON.parse(response.text) as string[] : []
+	if (output.length) {
+		set_cache(search_term, output)
+	}
+
 	return output.map(key => all_concepts.find(c => key === concept_key(c))!)
 }
 
@@ -80,4 +93,27 @@ function transform_concept(concept: Concept): { concept: string, gloss: string }
 
 function concept_key({ stem, sense, part_of_speech }: Concept): string {
 	return `${stem}-${sense}-${part_of_speech}`
+}
+
+const related_concept_cache: Map<string, [string[], Date]> = new Map()
+
+function get_from_cache(search_term: string): string[] | undefined {
+	const cached_value = related_concept_cache.get(search_term)
+	if (!cached_value) {
+		return undefined
+	}
+
+	const [results, timestamp] = cached_value
+
+	const a_week_ago = new Date()
+	a_week_ago.setDate(a_week_ago.getDate() - 7)
+	if (timestamp < a_week_ago) {
+		return undefined
+	}
+
+	return [...results]
+}
+
+function set_cache(search_term: string, results: string[]) {
+	related_concept_cache.set(search_term, [[...results], new Date()])
 }


### PR DESCRIPTION
Cache results from the Semantic Search for a week, currently held in memory on the server.

Remove dates and times from the concepts sent to the LLM.

Also make the Semantic Search dropdown show in red to draw attention and hopefully prevent someone from using it without meaning to.
<img width="1332" height="246" alt="image" src="https://github.com/user-attachments/assets/8d27f4b6-6f2d-49e0-9d98-26aeda67482a" />
