### PR TITLE
Show pending changes in search results

### DIFF
--- a/src/lib/Meaning.svelte
+++ b/src/lib/Meaning.svelte
@@ -1,11 +1,10 @@
-<script>
+<script lang="ts">
 	import Icon from '@iconify/svelte'
+	import PendingChange from './PendingChange.svelte'
 
-	/** @type {Concept} */
-	export let concept
+	let { concept, compact = false }: { concept: Concept, compact?: boolean } = $props()
 
-	/** @type {boolean} */
-	export let compact = false
+	let pending_change = $derived(concept.pending_changes.find(change => change.data.gloss))
 </script>
 
 {#if concept.status === 'not used'}
@@ -34,4 +33,10 @@
 	{/if}
 {:else}
 	{concept.gloss}
+	{#if pending_change}
+		<br />
+		<PendingChange>
+			{pending_change.data.gloss!.value}
+		</PendingChange>
+	{/if}
 {/if}

--- a/src/lib/PendingChange.svelte
+++ b/src/lib/PendingChange.svelte
@@ -1,0 +1,10 @@
+<script>
+	import Icon from '@iconify/svelte'
+</script>
+
+<div class="border border-info bg-info/5 text-info text-sm p-1 rounded-md flex flex-row items-center gap-1">
+	<span class="tooltip" data-tip="Pending change...">
+		<Icon icon="material-symbols:pending-outline" class="h-4 w-4" />
+	</span>
+	<slot />
+</div>

--- a/src/lib/PendingChange.svelte
+++ b/src/lib/PendingChange.svelte
@@ -4,7 +4,7 @@
 
 <div class="border border-info bg-info/5 text-info text-sm p-1 rounded-md flex flex-row items-center gap-1">
 	<span class="tooltip" data-tip="Pending change...">
-		<Icon icon="material-symbols:pending-outline" class="h-4 w-4" />
+		<Icon icon="mdi:clock-outline" class="h-4 w-4" />
 	</span>
 	<slot />
 </div>

--- a/src/lib/Table.svelte
+++ b/src/lib/Table.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { DetailedCard, Level, Occurrences, Meaning } from '$lib'
+	import PendingChange from '$lib/PendingChange.svelte'
 
 	/** @type {Concept[]} */
 	export let concepts
@@ -30,6 +31,7 @@
 
 	<tbody>
 		{#each concepts as concept (`${concept.stem}-${concept.sense}-${concept.part_of_speech}`)}
+			{@const pending_level_change = concept.pending_changes.find(change => change.data.level)}
 			<tr class="hover cursor-pointer" on:click={() => open(concept)}>
 				<td>
 					{concept.stem}
@@ -45,6 +47,11 @@
 				</td>
 				<td>
 					<Level level={concept.level} />
+					{#if pending_level_change}
+						<PendingChange>
+							<Level level={pending_level_change.data.level?.value || ''} />
+						</PendingChange>
+					{/if}
 				</td>
 				<td class="text-center">
 					<Occurrences {concept} />

--- a/src/lib/card/DetailedCard.svelte
+++ b/src/lib/card/DetailedCard.svelte
@@ -3,6 +3,7 @@
 	import { Details, Examples, Meaning } from '$lib'
 	import Header from './Header.svelte'
 	import SimplificationHints from './SimplificationHints.svelte'
+	import PendingChange from '$lib/PendingChange.svelte'
 	import { Category } from './categorization'
 	import { onMount } from 'svelte'
 	import { CONCEPT_FILTERS } from '$lib/filters'
@@ -40,8 +41,16 @@
 
 				{#if CONCEPT_FILTERS.IS_OR_WILL_BE_IN_ONTOLOGY(concept)}
 					{@const { part_of_speech, categories } = concept}
+					{@const pending_categories_change = concept.pending_changes.find(change => change.data.categories)}
 					<section class="prose mt-4 max-w-none">
 						<Category {part_of_speech} {categories} />
+
+						{#if pending_categories_change}
+							{@const pending_categories = pending_categories_change.data.categories?.value.filter(category => category) || []}
+							<PendingChange>
+								<Category {part_of_speech} categories={pending_categories} />
+							</PendingChange>
+						{/if}
 					</section>
 				{/if}
 

--- a/src/lib/card/Header.svelte
+++ b/src/lib/card/Header.svelte
@@ -1,14 +1,23 @@
-<script>
+<script lang="ts">
 	import { Level, Occurrences, ConceptKey } from '$lib'
+	import PendingChange from '$lib/PendingChange.svelte'
 
-	/** @type {Concept} */
-	export let concept
+	let { concept }: { concept: Concept } = $props()
+
+	let pending_change = $derived(concept.pending_changes.find(change => change.data.level))
 </script>
 
 <ConceptKey {concept} />
 
 <aside class="flex flex-col items-center gap-1 self-start">
-	<Level level={concept.level} />
+	<div class="flex flex-row items-center gap-1">
+		<Level level={concept.level} />
+		{#if pending_change}
+			<PendingChange>
+				<Level level={pending_change.data.level!.value} />
+			</PendingChange>
+		{/if}
+	</div>
 
 	<Occurrences {concept} />
 </aside>

--- a/src/lib/card/SummaryCard.svelte
+++ b/src/lib/card/SummaryCard.svelte
@@ -2,6 +2,7 @@
 	import Icon from '@iconify/svelte'
 	import Header from './Header.svelte'
 	import SimplificationHints from './SimplificationHints.svelte'
+	import PendingChange from '$lib/PendingChange.svelte'
 	import { Category } from './categorization'
 	import { DetailedCard, Meaning } from '$lib'
 	import { page } from '$app/state'
@@ -34,8 +35,16 @@
 
 		{#if concept.part_of_speech === 'Verb' && CONCEPT_FILTERS.IS_OR_WILL_BE_IN_ONTOLOGY(concept)}
 			{@const { part_of_speech, categories } = concept}
+			{@const pending_categories_change = concept.pending_changes.find(change => change.data.categories)}
 			<section class="prose mt-4 max-w-none">
 				<Category {part_of_speech} {categories} />
+				
+				{#if pending_categories_change}
+					{@const pending_categories = pending_categories_change.data.categories?.value.filter(category => category) || []}
+					<PendingChange>
+						<Category {part_of_speech} categories={pending_categories} />
+					</PendingChange>
+				{/if}
 			</section>
 		{/if}
 		

--- a/src/lib/card/categorization/SemanticCategorization.svelte
+++ b/src/lib/card/categorization/SemanticCategorization.svelte
@@ -5,10 +5,10 @@
 	$: name = categories[0]
 </script>
 
-<fieldset class="fieldset border border-base-300 rounded-box p-4">
-	<legend class="fieldset-legend font-semibold">Semantic categorization</legend>
+<fieldset class="fieldset border border-base-300 rounded-box p-2">
+	<legend class="fieldset-legend font-semibold ms-2">Semantic categorization</legend>
 
-	<p class="ms-4 mt-0 text-xl font-bold tracking-widest">
+	<p class="ms-4 mt-0 mb-3 text-lg font-semibold tracking-widest">
 		{name}
 	</p>
 </fieldset>

--- a/src/lib/server/index.d.ts
+++ b/src/lib/server/index.d.ts
@@ -31,6 +31,7 @@ interface Concept extends DbRowConcept {
 	occurrences: number
 	status: OntologyStatus
 	how_to_hints: SimplificationHint[]
+	pending_changes: OntologyChange[]
 }
 
 type OntologyStatus = 'in ontology' | 'approved' | 'suggested' | 'not used' | 'function_word'

--- a/src/lib/server/ontology.js
+++ b/src/lib/server/ontology.js
@@ -1,4 +1,5 @@
 import { decode_categorization, transform_curated_examples } from '$lib/transformers'
+import { get_pending_changes } from './changes/changes'
 
 // refs:
 // 	https://www.sqlite.org/lang_expr.html#the_like_glob_regexp_match_and_extract_operators
@@ -70,6 +71,11 @@ export const get_concepts = db => async concept_filter => {
 
 	const concepts = normalize(results)
 
+	const all_pending_changes = await get_pending_changes(db)
+	for (const concept of concepts) {
+		concept.pending_changes = all_pending_changes.filter(change => concepts_match(concept, change.concept))
+	}
+
 	const how_to_results = await get_simplification_hints(db)(concept_filter)
 	return merge_how_to_results(concepts, how_to_results)
 
@@ -96,6 +102,7 @@ function transform(match_from_db) {
 		curated_examples_raw: match_from_db.curated_examples,
 		status: 'in ontology',
 		how_to_hints: [],
+		pending_changes: [],
 	}
 }
 
@@ -226,14 +233,6 @@ function merge_how_to_results(concepts, how_to_results) {
 	return concepts
 
 	/**
-	 * @param {ConceptKey} a
-	 * @param {ConceptKey} b
-	 */
-	function concepts_match(a, b) {
-		return a.stem === b.stem && a.sense === b.sense && a.part_of_speech === b.part_of_speech
-	}
-
-	/**
 	 * @param {SimplificationHint} hint
 	 * @returns {Concept}
 	 */
@@ -262,6 +261,7 @@ function merge_how_to_results(concepts, how_to_results) {
 			curated_examples_raw: '',
 			status: hint.ontology_status,
 			how_to_hints: [hint],
+			pending_changes: [],
 		}
 	}
 
@@ -272,6 +272,14 @@ function merge_how_to_results(concepts, how_to_results) {
 	function create_concept_key({ stem, sense, part_of_speech }) {
 		return `${stem}-${sense}-${part_of_speech}`
 	}
+}
+
+/**
+ * @param {ConceptKey} a
+ * @param {ConceptKey} b
+ */
+function concepts_match(a, b) {
+	return a.stem === b.stem && a.sense === b.sense && a.part_of_speech === b.part_of_speech
 }
 
 /**

--- a/src/routes/protected/concept/create/+page.svelte
+++ b/src/routes/protected/concept/create/+page.svelte
@@ -51,7 +51,7 @@
 		</div>
 
 		{#if concept_data.sense}
-			{@const concept_for_header: Concept = { ...concept_data, categorization: '', curated_examples: [], curated_examples_raw: '', occurrences: 0, status: 'not used', how_to_hints: [], examples: '', id: '' }}
+			{@const concept_for_header: Concept = { ...concept_data, categorization: '', curated_examples: [], curated_examples_raw: '', occurrences: 0, status: 'not used', how_to_hints: [], pending_changes: [], examples: '', id: '' }}
 			<section class="prose card-title max-w-none justify-between">
 				<Header concept={concept_for_header} />
 			</section>

--- a/src/routes/protected/concept/update/+page.svelte
+++ b/src/routes/protected/concept/update/+page.svelte
@@ -10,7 +10,7 @@
 	let concept_data = $state(data.concept_data)
 	let initial_data = $state.snapshot(concept_data)
 	let is_dirty = $derived(!deep_equal(concept_data, initial_data))
-	let concept_for_header: Concept = $derived({ ...concept_data, categorization: '', curated_examples: [], curated_examples_raw: '', occurrences: 0, status: 'not used', how_to_hints: [], examples: '', id: '' })
+	let concept_for_header: Concept = $derived({ ...concept_data, categorization: '', curated_examples: [], curated_examples_raw: '', occurrences: 0, status: 'not used', how_to_hints: [], pending_changes: [], examples: '', id: '' })
 
 	function deep_equal(obj1: ConceptUpdateData, obj2: ConceptUpdateData): boolean {
 		return JSON.stringify(obj1) === JSON.stringify(obj2)


### PR DESCRIPTION
In the search results, show when there is a pending change for some of the data.

Hovering over the icon shows a tooltip saying `Pending change...`. I'm open to suggestions for this wording.

<img width="1886" height="744" alt="image" src="https://github.com/user-attachments/assets/902bf98b-01dc-4bfd-9546-5787adb65a99" />

<img width="1457" height="533" alt="image" src="https://github.com/user-attachments/assets/254a1fb2-b4ce-4dfb-a00b-7ba1edf0b4a0" />

<img width="1278" height="738" alt="image" src="https://github.com/user-attachments/assets/546c444a-f9e1-4978-95b5-daa6d22d5373" />

<img width="1288" height="739" alt="image" src="https://github.com/user-attachments/assets/d240223a-dde2-48cf-bacb-d4c37856ddd8" />

I'm also open to using a clock icon - see below for example. I'm not sure which I like better.
<img width="966" height="632" alt="image" src="https://github.com/user-attachments/assets/8c369739-b6bb-4b76-841c-e109d01cf246" />
(above uses `mdi:clock-outline`)